### PR TITLE
use get_stylesheet_directory to support child themes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
       }
     },
     "scripts": {
-      "test": "phpunit --colors=auto",
+      "test": "phpunit --colors=always --testdox",
       "lint": "phpcs -v inc/*",
       "changelog": "npx auto-changelog --template keepachangelog -v"
     },

--- a/inc/Enqueue.php
+++ b/inc/Enqueue.php
@@ -78,8 +78,9 @@ class Enqueue {
 	 * @param string         $version Version of your plugin/theme, used to generate query URL.
 	 * @param string         $type The type of enqueue, either 'plugin' or 'theme', same as wpackio.project.js.
 	 * @param string|boolean $pluginPath If this is a plugin, then pass absolute path of the plugin main file, otherwise pass false.
+	 * @param string 				 $themeType If this is a theme, then you can declare if it is a 'child' or 'regular' theme.
 	 */
-	public function __construct( $appName, $outputPath, $version, $type = 'plugin', $pluginPath = false ) {
+	public function __construct( $appName, $outputPath, $version, $type = 'plugin', $pluginPath = false, $themeType = 'regular' ) {
 		$this->appName = $appName;
 		$this->outputPath = $outputPath;
 		$this->version = $version;
@@ -88,10 +89,18 @@ class Enqueue {
 		}
 		$this->type = $type;
 		$this->pluginPath = $pluginPath;
+		$this->themeType = $themeType;
+		$themePath = get_template_directory();
+		$themeUri = get_template_directory_uri();
+
+		if ( $this->type === 'theme' && $this->$themeType === 'child' ) {
+			$themePath = get_stylesheet_directory();
+			$themeUri = get_stylesheet_directory_uri();
+		}
 
 		// Set the root path and URL
-		$filepath = \trailingslashit( \get_stylesheet_directory() ) . $this->outputPath . '/';
-		$url = \trailingslashit( \get_stylesheet_directory_uri() ) . $this->outputPath . '/';
+		$filepath = \trailingslashit( $themePath ) . $this->outputPath . '/';
+		$url = \trailingslashit( $themeUri ) . $this->outputPath . '/';
 		if ( 'plugin' === $this->type ) {
 			$filepath = \trailingslashit( dirname( $this->pluginPath ) ) . $this->outputPath . '/';
 			$url = \trailingslashit( \plugins_url( $this->outputPath, $this->pluginPath ) );

--- a/inc/Enqueue.php
+++ b/inc/Enqueue.php
@@ -90,8 +90,8 @@ class Enqueue {
 		$this->pluginPath = $pluginPath;
 
 		// Set the root path and URL
-		$filepath = \trailingslashit( \get_template_directory() ) . $this->outputPath . '/';
-		$url = \trailingslashit( \get_template_directory_uri() ) . $this->outputPath . '/';
+		$filepath = \trailingslashit( \get_stylesheet_directory() ) . $this->outputPath . '/';
+		$url = \trailingslashit( \get_stylesheet_directory_uri() ) . $this->outputPath . '/';
 		if ( 'plugin' === $this->type ) {
 			$filepath = \trailingslashit( dirname( $this->pluginPath ) ) . $this->outputPath . '/';
 			$url = \trailingslashit( \plugins_url( $this->outputPath, $this->pluginPath ) );

--- a/inc/Enqueue.php
+++ b/inc/Enqueue.php
@@ -78,7 +78,7 @@ class Enqueue {
 	 * @param string         $version Version of your plugin/theme, used to generate query URL.
 	 * @param string         $type The type of enqueue, either 'plugin' or 'theme', same as wpackio.project.js.
 	 * @param string|boolean $pluginPath If this is a plugin, then pass absolute path of the plugin main file, otherwise pass false.
-	 * @param string 				 $themeType If this is a theme, then you can declare if it is a 'child' or 'regular' theme.
+	 * @param string         $themeType If this is a theme, then you can declare if it is a 'child' or 'regular' theme.
 	 */
 	public function __construct( $appName, $outputPath, $version, $type = 'plugin', $pluginPath = false, $themeType = 'regular' ) {
 		$this->appName = $appName;

--- a/inc/Enqueue.php
+++ b/inc/Enqueue.php
@@ -80,12 +80,12 @@ class Enqueue {
 	 *
 	 * @throws \LogicException If $type is not plugin or theme.
 	 *
-	 * @param string         $appName Name of the application, same as wpackio.project.js.
-	 * @param string         $outputPath Output path relative to the root of this plugin/theme, same as wpackio.project.js.
-	 * @param string         $version Version of your plugin/theme, used to generate query URL.
-	 * @param string         $type The type of enqueue, either 'plugin' or 'theme', same as wpackio.project.js.
-	 * @param string|boolean $pluginPath If this is a plugin, then pass absolute path of the plugin main file, otherwise pass false.
-	 * @param string         $themeType If this is a theme, then you can declare if it is a 'child' or 'regular' theme.
+	 * @param string         $appName     Name of the application, same as wpackio.project.js.
+	 * @param string         $outputPath  Output path relative to the root of this plugin/theme, same as wpackio.project.js.
+	 * @param string         $version     Version of your plugin/theme, used to generate query URL.
+	 * @param string         $type        The type of enqueue, either 'plugin' or 'theme', same as wpackio.project.js.
+	 * @param string|boolean $pluginPath  If this is a plugin, then pass absolute path of the plugin main file, otherwise pass false.
+	 * @param string         $themeType   If this is a theme, then you can declare if it is a 'child' or 'regular' theme.
 	 */
 	public function __construct( $appName, $outputPath, $version, $type = 'plugin', $pluginPath = false, $themeType = 'regular' ) {
 		$this->appName = $appName;
@@ -97,12 +97,12 @@ class Enqueue {
 		$this->type = $type;
 		$this->pluginPath = $pluginPath;
 		$this->themeType = $themeType;
-		$themePath = get_template_directory();
-		$themeUri = get_template_directory_uri();
+		$themePath = \get_template_directory();
+		$themeUri = \get_template_directory_uri();
 
-		if ( $this->type === 'theme' && $this->$themeType === 'child' ) {
-			$themePath = get_stylesheet_directory();
-			$themeUri = get_stylesheet_directory_uri();
+		if ( 'theme' === $this->type && 'child' === $this->themeType ) {
+			$themePath = \get_stylesheet_directory();
+			$themeUri = \get_stylesheet_directory_uri();
 		}
 
 		// Set the root path and URL

--- a/inc/Enqueue.php
+++ b/inc/Enqueue.php
@@ -69,6 +69,13 @@ class Enqueue {
 	private $appName = '';
 
 	/**
+	 * Theme type ('child' or 'regular').
+	 *
+	 * @var string
+	 */
+	private $themeType = '';
+
+	/**
 	 * Create an instance of the Enqueue helper class.
 	 *
 	 * @throws \LogicException If $type is not plugin or theme.

--- a/tests/testcases/EnqueueTest.php
+++ b/tests/testcases/EnqueueTest.php
@@ -37,8 +37,8 @@ class EnqueueTest extends TestCase {
 		// Stub out a few functions we will need
 		// with predefined output
 		\Brain\Monkey\Functions\stubs([
-			'get_template_directory' => $this->td,
-			'get_template_directory_uri' => $this->tdu,
+			'get_stylesheet_directory' => $this->td,
+			'get_stylesheet_directory_uri' => $this->tdu,
 			'plugins_url' => $this->pu,
 		]);
 		// Stub some returnFirstArguments function

--- a/tests/testcases/EnqueueTest.php
+++ b/tests/testcases/EnqueueTest.php
@@ -83,9 +83,14 @@ class EnqueueTest extends TestCase {
 		$this->assertContains( 'window.__wpackIofoodist=\'' . $this->tdu . '/dist/\'', $result );
 	}
 
-	public function test_getUrl_for_theme() {
+	public function test_getUrl_for_regular_theme() {
 		$enqueue = new \WPackio\Enqueue( 'foo', 'dist', '1.0.0', 'theme', false, 'regular' );
 		$this->assertEquals( $this->tdu . '/dist/app/main.js', $enqueue->getUrl( 'app/main.js' ) );
+	}
+
+	public function test_getUrl_for_child_theme() {
+		$enqueue = new \WPackio\Enqueue( 'foo', 'dist', '1.0.0', 'theme', false, 'child' );
+		$this->assertEquals( $this->childThemeTemplateDirectoryUri . '/dist/app/main.js', $enqueue->getUrl( 'app/main.js' ) );
 	}
 
 	public function test_getUrl_for_plugin() {
@@ -119,7 +124,7 @@ class EnqueueTest extends TestCase {
 		$enqueue->getAssets( 'app', 'noop', [] );
 	}
 
-	public function test_getAssets_for_regular_theme() {
+	public function test_getAssets_for_theme() {
 		$enqueue = new \WPackio\Enqueue( 'foo', 'dist', '1.0.0', 'theme', false, 'regular' );
 		$assets = $enqueue->getAssets( 'app', 'main', [
 			'js' => true,
@@ -145,37 +150,6 @@ class EnqueueTest extends TestCase {
 			$this->assertArrayHasKey( 'url', $css );
 			$this->assertArrayHasKey( 'handle', $css );
 			$this->assertContains( $this->tdu . '/dist/app/', $css['url'] );
-		}
-
-		$this->assertMatchesSnapshot( $assets );
-	}
-
-	public function test_getAssets_for_child_theme() {
-		$enqueue = new \WPackio\Enqueue( 'foo', 'dist', '1.0.0', 'theme', false, 'child' );
-		$assets = $enqueue->getAssets( 'app', 'main', [
-			'js' => true,
-			'css' => true,
-			'js_dep' => [],
-			'css_dep' => [],
-			'identifier' => false,
-			'in_footer' => true,
-			'media' => 'all',
-		] );
-		// expect on js
-		$this->assertArrayHasKey( 'js', $assets );
-		foreach ( $assets['js']  as $js ) {
-			$this->assertArrayHasKey( 'url', $js );
-			$this->assertArrayHasKey( 'handle', $js );
-			$this->assertContains( $this->childThemeTemplateDirectoryUri . '/dist/app/', $js['url'] );
-		}
-
-
-		// expect on js
-		$this->assertArrayHasKey( 'css', $assets );
-		foreach ( $assets['css']  as $css ) {
-			$this->assertArrayHasKey( 'url', $css );
-			$this->assertArrayHasKey( 'handle', $css );
-			$this->assertContains( $this->childThemeTemplateDirectoryUri . '/dist/app/', $css['url'] );
 		}
 
 		$this->assertMatchesSnapshot( $assets );

--- a/tests/testcases/EnqueueTest.php
+++ b/tests/testcases/EnqueueTest.php
@@ -12,19 +12,25 @@ class EnqueueTest extends TestCase {
 	 * Mocked Template Directory Uri
 	 * @var string
 	 */
-	protected $tdu = 'http://example.com/path/to/template/directory';
+	protected $templateDirectoryUri = 'http://example.com/path/to/template/directory';
 
 	/**
-	 * Mocked Child Theme Directory Uri
+	 * Mocked Stylesheet Directory Uri
 	 * @var string
 	 */
-	protected $childThemeTemplateDirectoryUri = 'http://example.com/path/to/child_theme_template/directory';
+	protected $stylesheetDirectoryUri = 'http://example.com/path/to/child_theme_template/directory';
 
 	/**
 	 * Mocked Template Directory path.
 	 * @var string
 	 */
-	protected $td = __DIR__ . '/../data';
+	protected $templateDirectory = __DIR__ . '/../data';
+
+	/**
+	 * Mocked Stylesheet Directory path.
+	 * @var string
+	 */
+	protected $stylesheetDirectory = __DIR__ . '/../data';
 
 	/**
 	 * Mocked Plugin Uri.
@@ -43,9 +49,10 @@ class EnqueueTest extends TestCase {
 		// Stub out a few functions we will need
 		// with predefined output
 		\Brain\Monkey\Functions\stubs([
-			'get_template_directory' => $this->td,
-			'get_template_directory_uri' => $this->tdu,
-			'get_stylesheet_directory_uri' => $this->childThemeTemplateDirectoryUri,
+			'get_template_directory' => $this->templateDirectory,
+			'get_template_directory_uri' => $this->templateDirectoryUri,
+			'get_stylesheet_directory' => $this->stylesheetDirectory,
+			'get_stylesheet_directory_uri' => $this->stylesheetDirectoryUri,
 			'plugins_url' => $this->pu,
 		]);
 		// Stub some returnFirstArguments function
@@ -55,6 +62,10 @@ class EnqueueTest extends TestCase {
 			'sanitize_title_with_dashes'
 		]);
 	}
+
+	/**
+	 * @testdox Constructor adds WordPress actions
+	 */
 	public function test_construct() {
 		$enqueue = new \WPackio\Enqueue( 'foo', 'dist', '1.0.0', 'plugin', '/plugin/path/plugin.php' );
 		// We expect hooks on both wp_head and admin_head
@@ -62,11 +73,17 @@ class EnqueueTest extends TestCase {
 		$this->assertTrue( has_action( 'admin_print_scripts', 'WPackio\\Enqueue->printPublicPath()', -1000 ) );
 	}
 
+	/**
+	 * @testdox Constructor throws exception on invalid $type
+	 */
 	public function test_construct_throws_on_invalid_type() {
 		$this->expectException('\LogicException');
 		$enqueue = new \WPackio\Enqueue( 'foo', 'dist', '1.0.0', 'aasdasd', '/plugin/path/plugin.php' );
 	}
 
+	/**
+	 * @testdox `printPublicPath` works for plugins
+	 */
 	public function test_printPublicPath_for_plugin() {
 		$enqueue = new \WPackio\Enqueue( 'foo', 'dist', '1.0.0', 'plugin', '/plugin/path/plugin.php' );
 		ob_start();
@@ -75,29 +92,55 @@ class EnqueueTest extends TestCase {
 		$this->assertContains( 'window.__wpackIofoodist=\'' . $this->pu . '/\'', $result );
 	}
 
-	public function test_printPublicPath_for_theme() {
+	/**
+	 * @testdox `printPublicPath` works for regular themes
+	 */
+	public function test_printPublicPath_for_regular_theme() {
 		$enqueue = new \WPackio\Enqueue( 'foo', 'dist', '1.0.0', 'theme', false, 'regular' );
 		ob_start();
 		$enqueue->printPublicPath();
 		$result = ob_get_clean();
-		$this->assertContains( 'window.__wpackIofoodist=\'' . $this->tdu . '/dist/\'', $result );
+		$this->assertContains( 'window.__wpackIofoodist=\'' . $this->templateDirectoryUri . '/dist/\'', $result );
 	}
 
+	/**
+	 * @testdox `printPublicPath` works child themes
+	 */
+	public function test_printPublicPath_for_child_theme() {
+		$enqueue = new \WPackio\Enqueue( 'foo', 'dist', '1.0.0', 'theme', false, 'child' );
+		ob_start();
+		$enqueue->printPublicPath();
+		$result = ob_get_clean();
+		$this->assertContains( 'window.__wpackIofoodist=\'' . $this->stylesheetDirectoryUri . '/dist/\'', $result );
+	}
+
+	/**
+	 * @testdox `getUrl` works for regular themes
+	 */
 	public function test_getUrl_for_regular_theme() {
 		$enqueue = new \WPackio\Enqueue( 'foo', 'dist', '1.0.0', 'theme', false, 'regular' );
-		$this->assertEquals( $this->tdu . '/dist/app/main.js', $enqueue->getUrl( 'app/main.js' ) );
+		$this->assertEquals( $this->templateDirectoryUri . '/dist/app/main.js', $enqueue->getUrl( 'app/main.js' ) );
 	}
 
+	/**
+	 * @testdox `getUrl` works for child themes
+	 */
 	public function test_getUrl_for_child_theme() {
 		$enqueue = new \WPackio\Enqueue( 'foo', 'dist', '1.0.0', 'theme', false, 'child' );
-		$this->assertEquals( $this->childThemeTemplateDirectoryUri . '/dist/app/main.js', $enqueue->getUrl( 'app/main.js' ) );
+		$this->assertEquals( $this->stylesheetDirectoryUri . '/dist/app/main.js', $enqueue->getUrl( 'app/main.js' ) );
 	}
 
+	/**
+	 * @testdox `getUrl` works for plugins
+	 */
 	public function test_getUrl_for_plugin() {
 		$enqueue = new \WPackio\Enqueue( 'foo', 'dist', '1.0.0', 'plugin', '/path/to/plugin.php' );
 		$this->assertEquals( $this->pu . '/app/main.js', $enqueue->getUrl( 'app/main.js' ) );
 	}
 
+	/**
+	 * @testdox `getManifest` works if file is valid
+	 */
 	public function test_getManifest() {
 		$path_to_manifest = dirname( $this->pp ) . '/dist/app/manifest.json';
 		$enqueue = new \WPackio\Enqueue( 'foo', 'dist', '1.0.0', 'plugin', $this->pp );
@@ -106,25 +149,37 @@ class EnqueueTest extends TestCase {
 		$this->assertMatchesSnapshot( $manifest );
 	}
 
+	/**
+	 * @testdox `getManifest` throws if file not found
+	 */
 	public function test_getManifest_throws_if_file_not_found() {
 		$this->expectException( '\LogicException' );
 		$enqueue = new \WPackio\Enqueue( 'foo', 'dist', '1.0.0', 'plugin', $this->pp );
 		$enqueue->getManifest( 'noop' );
 	}
 
+	/**
+	 * @testdox `getManifest` throws if file not valid JSON
+	 */
 	public function test_getManifest_throws_if_file_not_valid() {
 		$this->expectException( '\LogicException' );
 		$enqueue = new \WPackio\Enqueue( 'foo', 'dist', '1.0.0', 'plugin', $this->pp );
 		$enqueue->getManifest( 'broken' );
 	}
 
+	/**
+	 * @testdox `getAssets` throws on invalid entrypoint
+	 */
 	public function test_getAssets_throws_on_invalid_entrypoint() {
 		$this->expectException('\LogicException');
 		$enqueue = new \WPackio\Enqueue( 'foo', 'dist', '1.0.0', 'theme', false, 'regular' );
 		$enqueue->getAssets( 'app', 'noop', [] );
 	}
 
-	public function test_getAssets_for_theme() {
+	/**
+	 * @testdox `getAssets` works for regular themes
+	 */
+	public function test_getAssets_for_regular_theme() {
 		$enqueue = new \WPackio\Enqueue( 'foo', 'dist', '1.0.0', 'theme', false, 'regular' );
 		$assets = $enqueue->getAssets( 'app', 'main', [
 			'js' => true,
@@ -140,7 +195,7 @@ class EnqueueTest extends TestCase {
 		foreach ( $assets['js']  as $js ) {
 			$this->assertArrayHasKey( 'url', $js );
 			$this->assertArrayHasKey( 'handle', $js );
-			$this->assertContains( $this->tdu . '/dist/app/', $js['url'] );
+			$this->assertContains( $this->templateDirectoryUri . '/dist/app/', $js['url'] );
 		}
 
 
@@ -149,12 +204,49 @@ class EnqueueTest extends TestCase {
 		foreach ( $assets['css']  as $css ) {
 			$this->assertArrayHasKey( 'url', $css );
 			$this->assertArrayHasKey( 'handle', $css );
-			$this->assertContains( $this->tdu . '/dist/app/', $css['url'] );
+			$this->assertContains( $this->templateDirectoryUri . '/dist/app/', $css['url'] );
 		}
 
 		$this->assertMatchesSnapshot( $assets );
 	}
 
+	/**
+	 * @testdox `getAssets` works for child themes
+	 */
+	public function test_getAssets_for_child_theme() {
+		$enqueue = new \WPackio\Enqueue( 'foo', 'dist', '1.0.0', 'theme', false, 'child' );
+		$assets = $enqueue->getAssets( 'app', 'main', [
+			'js' => true,
+			'css' => true,
+			'js_dep' => [],
+			'css_dep' => [],
+			'identifier' => false,
+			'in_footer' => true,
+			'media' => 'all',
+		] );
+		// expect on js
+		$this->assertArrayHasKey( 'js', $assets );
+		foreach ( $assets['js']  as $js ) {
+			$this->assertArrayHasKey( 'url', $js );
+			$this->assertArrayHasKey( 'handle', $js );
+			$this->assertContains( $this->stylesheetDirectoryUri . '/dist/app/', $js['url'] );
+		}
+
+
+		// expect on js
+		$this->assertArrayHasKey( 'css', $assets );
+		foreach ( $assets['css']  as $css ) {
+			$this->assertArrayHasKey( 'url', $css );
+			$this->assertArrayHasKey( 'handle', $css );
+			$this->assertContains( $this->stylesheetDirectoryUri . '/dist/app/', $css['url'] );
+		}
+
+		$this->assertMatchesSnapshot( $assets );
+	}
+
+	/**
+	 * @testdox `getAssets` works for plugins
+	 */
 	public function test_getAssets_for_plugin() {
 		$enqueue = new \WPackio\Enqueue( 'foo', 'dist', '1.0.0', 'plugin', $this->pp );
 		$assets = $enqueue->getAssets( 'app', 'main', [
@@ -185,6 +277,9 @@ class EnqueueTest extends TestCase {
 		$this->assertMatchesSnapshot( $assets );
 	}
 
+	/**
+	 * @testdox `getAssets` has same handle for every runtime asset
+	 */
 	public function test_getAssets_has_same_handle_for_every_runtime() {
 		$runtime_handles = [];
 		$enqueue = new \WPackio\Enqueue( 'foo', 'dist', '1.0.0', 'plugin', $this->pp );
@@ -224,7 +319,9 @@ class EnqueueTest extends TestCase {
 		);
 	}
 
-
+	/**
+	 * @testdox `register` calls proper WordPress APIs
+	 */
 	public function test_register() {
 		// Get the manifest beforehand for assertion
 		$path_to_manifest = dirname( $this->pp ) . '/dist/app/manifest.json';
@@ -267,6 +364,9 @@ class EnqueueTest extends TestCase {
 		$this->assertMatchesSnapshot( $enqueue_assets );
 	}
 
+	/**
+	 * @testdox `enqueue` calls proper WordPress APIs
+	 */
 	public function test_enqueue() {
 		// Arrange
 		$config = [
@@ -324,6 +424,9 @@ class EnqueueTest extends TestCase {
 		$enqueue->enqueue( 'app', 'main', $config );
 	}
 
+	/**
+	 * @testdox `getHandle` throws exception on invalid type
+	 */
 	public function test_getHandle_throws_exception() {
 		$this->expectException( '\LogicException' );
 		$enqueue = new \WPackio\Enqueue( 'foo', 'dist', '1.0.0', 'plugin', $this->pp );

--- a/tests/testcases/__snapshots__/EnqueueTest__test_getAssets_for_child_theme__1.php
+++ b/tests/testcases/__snapshots__/EnqueueTest__test_getAssets_for_child_theme__1.php
@@ -1,0 +1,28 @@
+<?php return array (
+  'css' => 
+  array (
+    0 => 
+    array (
+      'handle' => 'wpackio_fooapp_app/main.css_style',
+      'url' => 'http://example.com/path/to/child_theme_template/directory/dist/app/main.css',
+    ),
+  ),
+  'js' => 
+  array (
+    0 => 
+    array (
+      'handle' => 'wpackio_fooapp_app/runtime.js_script',
+      'url' => 'http://example.com/path/to/child_theme_template/directory/dist/app/runtime.js',
+    ),
+    1 => 
+    array (
+      'handle' => 'wpackio_fooapp_app/vendor.js_script',
+      'url' => 'http://example.com/path/to/child_theme_template/directory/dist/app/vendor.js',
+    ),
+    2 => 
+    array (
+      'handle' => 'wpackio_fooapp_app/main.js_script',
+      'url' => 'http://example.com/path/to/child_theme_template/directory/dist/app/main.js',
+    ),
+  ),
+);

--- a/tests/testcases/__snapshots__/EnqueueTest__test_getAssets_for_regular_theme__1.php
+++ b/tests/testcases/__snapshots__/EnqueueTest__test_getAssets_for_regular_theme__1.php
@@ -1,0 +1,28 @@
+<?php return array (
+  'css' => 
+  array (
+    0 => 
+    array (
+      'handle' => 'wpackio_fooapp_app/main.css_style',
+      'url' => 'http://example.com/path/to/template/directory/dist/app/main.css',
+    ),
+  ),
+  'js' => 
+  array (
+    0 => 
+    array (
+      'handle' => 'wpackio_fooapp_app/runtime.js_script',
+      'url' => 'http://example.com/path/to/template/directory/dist/app/runtime.js',
+    ),
+    1 => 
+    array (
+      'handle' => 'wpackio_fooapp_app/vendor.js_script',
+      'url' => 'http://example.com/path/to/template/directory/dist/app/vendor.js',
+    ),
+    2 => 
+    array (
+      'handle' => 'wpackio_fooapp_app/main.js_script',
+      'url' => 'http://example.com/path/to/template/directory/dist/app/main.js',
+    ),
+  ),
+);


### PR DESCRIPTION
Hi @swashata . Thanks for this plugin and project! 

I'm trying to add wpack.io to a legacy project that uses parent and child wordpress themes. With [`get_template_directory`](https://codex.wordpress.org/Function_Reference/get_template_directory) the root output path is always starting in the parent theme directory. In my project the child theme is active and I'd like the root output path to start there.

What do you think of changing the root to start with [`get_stylesheet_directory`](https://codex.wordpress.org/Function_Reference/get_stylesheet_directory) instead?