### PR TITLE
Don't export tests/vscode files in composer.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+tests/ export-ignore
+.vscode/ export-ignore
+.gitattributes export-ignore


### PR DESCRIPTION
Right now, when using composer to load this library, the tests directory also gets installed. This is problematic since Google Search Console will pick up these file and cause site verification issues.

Thanks for a wonderful library.